### PR TITLE
[mixed-content] Check if an URL is potentially trustworthy to block/upgrade

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/meta/sandbox-iframe-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/meta/sandbox-iframe-expected.txt
@@ -1,5 +1,5 @@
 self is derived correctly inside inside a sandboxed iframe.
 
 
-FAIL img-src 'self' works when specified in a meta tag. assert_equals: expected "PASS" but got "FAIL"
+PASS img-src 'self' works when specified in a meta tag.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-classic-data.http-rp/opt-in/fetch.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-classic-data.http-rp/opt-in/fetch.https-expected.txt
@@ -5,8 +5,8 @@ PASS Mixed-Content: Expects blocked for fetch to cross-http origin and keep-sche
 PASS Mixed-Content: Expects blocked for fetch to cross-http origin and no-redirect redirection from https context.
 PASS Mixed-Content: Expects blocked for fetch to cross-http origin and swap-scheme redirection from https context.
 PASS Mixed-Content: Expects blocked for fetch to cross-https origin and swap-scheme redirection from https context.
-FAIL Mixed-Content: Expects blocked for fetch to same-http origin and keep-scheme redirection from https context. assert_equals: The resource request should be 'blocked'. expected "blocked" but got "allowed"
-FAIL Mixed-Content: Expects blocked for fetch to same-http origin and no-redirect redirection from https context. assert_equals: The resource request should be 'blocked'. expected "blocked" but got "allowed"
-FAIL Mixed-Content: Expects blocked for fetch to same-http origin and swap-scheme redirection from https context. assert_equals: The resource request should be 'blocked'. expected "blocked" but got "allowed"
-FAIL Mixed-Content: Expects blocked for fetch to same-https origin and swap-scheme redirection from https context. assert_equals: The resource request should be 'blocked'. expected "blocked" but got "allowed"
+PASS Mixed-Content: Expects blocked for fetch to same-http origin and keep-scheme redirection from https context.
+PASS Mixed-Content: Expects blocked for fetch to same-http origin and no-redirect redirection from https context.
+PASS Mixed-Content: Expects blocked for fetch to same-http origin and swap-scheme redirection from https context.
+PASS Mixed-Content: Expects blocked for fetch to same-https origin and swap-scheme redirection from https context.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-classic-data.http-rp/opt-in/websocket.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-classic-data.http-rp/opt-in/websocket.https-expected.txt
@@ -1,5 +1,5 @@
 
 PASS Mixed-Content: Expects allowed for websocket to same-wss origin and no-redirect redirection from https context.
 PASS Mixed-Content: Expects blocked for websocket to cross-ws origin and no-redirect redirection from https context.
-FAIL Mixed-Content: Expects blocked for websocket to same-ws origin and no-redirect redirection from https context. assert_equals: The resource request should be 'blocked'. expected "blocked" but got "allowed"
+PASS Mixed-Content: Expects blocked for websocket to same-ws origin and no-redirect redirection from https context.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-classic-data.http-rp/opt-in/xhr.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-classic-data.http-rp/opt-in/xhr.https-expected.txt
@@ -5,8 +5,8 @@ PASS Mixed-Content: Expects blocked for xhr to cross-http origin and keep-scheme
 PASS Mixed-Content: Expects blocked for xhr to cross-http origin and no-redirect redirection from https context.
 PASS Mixed-Content: Expects blocked for xhr to cross-http origin and swap-scheme redirection from https context.
 PASS Mixed-Content: Expects blocked for xhr to cross-https origin and swap-scheme redirection from https context.
-FAIL Mixed-Content: Expects blocked for xhr to same-http origin and keep-scheme redirection from https context. assert_equals: The resource request should be 'blocked'. expected "blocked" but got "allowed"
-FAIL Mixed-Content: Expects blocked for xhr to same-http origin and no-redirect redirection from https context. assert_equals: The resource request should be 'blocked'. expected "blocked" but got "allowed"
-FAIL Mixed-Content: Expects blocked for xhr to same-http origin and swap-scheme redirection from https context. assert_equals: The resource request should be 'blocked'. expected "blocked" but got "allowed"
-FAIL Mixed-Content: Expects blocked for xhr to same-https origin and swap-scheme redirection from https context. assert_equals: The resource request should be 'blocked'. expected "blocked" but got "allowed"
+PASS Mixed-Content: Expects blocked for xhr to same-http origin and keep-scheme redirection from https context.
+PASS Mixed-Content: Expects blocked for xhr to same-http origin and no-redirect redirection from https context.
+PASS Mixed-Content: Expects blocked for xhr to same-http origin and swap-scheme redirection from https context.
+PASS Mixed-Content: Expects blocked for xhr to same-https origin and swap-scheme redirection from https context.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-classic-data.meta/opt-in/fetch.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-classic-data.meta/opt-in/fetch.https-expected.txt
@@ -1,5 +1,5 @@
 
 PASS Mixed-Content: Expects allowed for fetch to same-https origin and no-redirect redirection from https context.
 PASS Mixed-Content: Expects blocked for fetch to cross-http origin and no-redirect redirection from https context.
-FAIL Mixed-Content: Expects blocked for fetch to same-http origin and no-redirect redirection from https context. assert_equals: The resource request should be 'blocked'. expected "blocked" but got "allowed"
+PASS Mixed-Content: Expects blocked for fetch to same-http origin and no-redirect redirection from https context.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-classic-data.meta/opt-in/websocket.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-classic-data.meta/opt-in/websocket.https-expected.txt
@@ -1,5 +1,5 @@
 
 PASS Mixed-Content: Expects allowed for websocket to same-wss origin and no-redirect redirection from https context.
 PASS Mixed-Content: Expects blocked for websocket to cross-ws origin and no-redirect redirection from https context.
-FAIL Mixed-Content: Expects blocked for websocket to same-ws origin and no-redirect redirection from https context. assert_equals: The resource request should be 'blocked'. expected "blocked" but got "allowed"
+PASS Mixed-Content: Expects blocked for websocket to same-ws origin and no-redirect redirection from https context.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-classic-data.meta/opt-in/xhr.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-classic-data.meta/opt-in/xhr.https-expected.txt
@@ -1,5 +1,5 @@
 
 PASS Mixed-Content: Expects allowed for xhr to same-https origin and no-redirect redirection from https context.
 PASS Mixed-Content: Expects blocked for xhr to cross-http origin and no-redirect redirection from https context.
-FAIL Mixed-Content: Expects blocked for xhr to same-http origin and no-redirect redirection from https context. assert_equals: The resource request should be 'blocked'. expected "blocked" but got "allowed"
+PASS Mixed-Content: Expects blocked for xhr to same-http origin and no-redirect redirection from https context.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-classic-data.meta/unset/fetch.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-classic-data.meta/unset/fetch.https-expected.txt
@@ -4,7 +4,7 @@ PASS Mixed-Content: Expects allowed for fetch to same-https origin and no-redire
 PASS Mixed-Content: Expects blocked for fetch to cross-http origin and keep-scheme redirection from https context.
 PASS Mixed-Content: Expects blocked for fetch to cross-http origin and no-redirect redirection from https context.
 PASS Mixed-Content: Expects blocked for fetch to cross-http origin and swap-scheme redirection from https context.
-FAIL Mixed-Content: Expects blocked for fetch to same-http origin and keep-scheme redirection from https context. assert_equals: The resource request should be 'blocked'. expected "blocked" but got "allowed"
-FAIL Mixed-Content: Expects blocked for fetch to same-http origin and no-redirect redirection from https context. assert_equals: The resource request should be 'blocked'. expected "blocked" but got "allowed"
-FAIL Mixed-Content: Expects blocked for fetch to same-http origin and swap-scheme redirection from https context. assert_equals: The resource request should be 'blocked'. expected "blocked" but got "allowed"
+PASS Mixed-Content: Expects blocked for fetch to same-http origin and keep-scheme redirection from https context.
+PASS Mixed-Content: Expects blocked for fetch to same-http origin and no-redirect redirection from https context.
+PASS Mixed-Content: Expects blocked for fetch to same-http origin and swap-scheme redirection from https context.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-classic-data.meta/unset/websocket.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-classic-data.meta/unset/websocket.https-expected.txt
@@ -1,5 +1,5 @@
 
 PASS Mixed-Content: Expects allowed for websocket to same-wss origin and no-redirect redirection from https context.
 PASS Mixed-Content: Expects blocked for websocket to cross-ws origin and no-redirect redirection from https context.
-FAIL Mixed-Content: Expects blocked for websocket to same-ws origin and no-redirect redirection from https context. assert_equals: The resource request should be 'blocked'. expected "blocked" but got "allowed"
+PASS Mixed-Content: Expects blocked for websocket to same-ws origin and no-redirect redirection from https context.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-classic-data.meta/unset/xhr.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-classic-data.meta/unset/xhr.https-expected.txt
@@ -4,7 +4,7 @@ PASS Mixed-Content: Expects allowed for xhr to same-https origin and no-redirect
 PASS Mixed-Content: Expects blocked for xhr to cross-http origin and keep-scheme redirection from https context.
 PASS Mixed-Content: Expects blocked for xhr to cross-http origin and no-redirect redirection from https context.
 PASS Mixed-Content: Expects blocked for xhr to cross-http origin and swap-scheme redirection from https context.
-FAIL Mixed-Content: Expects blocked for xhr to same-http origin and keep-scheme redirection from https context. assert_equals: The resource request should be 'blocked'. expected "blocked" but got "allowed"
-FAIL Mixed-Content: Expects blocked for xhr to same-http origin and no-redirect redirection from https context. assert_equals: The resource request should be 'blocked'. expected "blocked" but got "allowed"
-FAIL Mixed-Content: Expects blocked for xhr to same-http origin and swap-scheme redirection from https context. assert_equals: The resource request should be 'blocked'. expected "blocked" but got "allowed"
+PASS Mixed-Content: Expects blocked for xhr to same-http origin and keep-scheme redirection from https context.
+PASS Mixed-Content: Expects blocked for xhr to same-http origin and no-redirect redirection from https context.
+PASS Mixed-Content: Expects blocked for xhr to same-http origin and swap-scheme redirection from https context.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-module-data.http-rp/opt-in/fetch.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-module-data.http-rp/opt-in/fetch.https-expected.txt
@@ -5,8 +5,8 @@ PASS Mixed-Content: Expects blocked for fetch to cross-http origin and keep-sche
 PASS Mixed-Content: Expects blocked for fetch to cross-http origin and no-redirect redirection from https context.
 PASS Mixed-Content: Expects blocked for fetch to cross-http origin and swap-scheme redirection from https context.
 PASS Mixed-Content: Expects blocked for fetch to cross-https origin and swap-scheme redirection from https context.
-FAIL Mixed-Content: Expects blocked for fetch to same-http origin and keep-scheme redirection from https context. assert_equals: The resource request should be 'blocked'. expected "blocked" but got "allowed"
-FAIL Mixed-Content: Expects blocked for fetch to same-http origin and no-redirect redirection from https context. assert_equals: The resource request should be 'blocked'. expected "blocked" but got "allowed"
-FAIL Mixed-Content: Expects blocked for fetch to same-http origin and swap-scheme redirection from https context. assert_equals: The resource request should be 'blocked'. expected "blocked" but got "allowed"
-FAIL Mixed-Content: Expects blocked for fetch to same-https origin and swap-scheme redirection from https context. assert_equals: The resource request should be 'blocked'. expected "blocked" but got "allowed"
+PASS Mixed-Content: Expects blocked for fetch to same-http origin and keep-scheme redirection from https context.
+PASS Mixed-Content: Expects blocked for fetch to same-http origin and no-redirect redirection from https context.
+PASS Mixed-Content: Expects blocked for fetch to same-http origin and swap-scheme redirection from https context.
+PASS Mixed-Content: Expects blocked for fetch to same-https origin and swap-scheme redirection from https context.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-module-data.http-rp/opt-in/websocket.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-module-data.http-rp/opt-in/websocket.https-expected.txt
@@ -1,5 +1,5 @@
 
 PASS Mixed-Content: Expects allowed for websocket to same-wss origin and no-redirect redirection from https context.
 PASS Mixed-Content: Expects blocked for websocket to cross-ws origin and no-redirect redirection from https context.
-FAIL Mixed-Content: Expects blocked for websocket to same-ws origin and no-redirect redirection from https context. assert_equals: The resource request should be 'blocked'. expected "blocked" but got "allowed"
+PASS Mixed-Content: Expects blocked for websocket to same-ws origin and no-redirect redirection from https context.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-module-data.http-rp/opt-in/xhr.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-module-data.http-rp/opt-in/xhr.https-expected.txt
@@ -5,8 +5,8 @@ PASS Mixed-Content: Expects blocked for xhr to cross-http origin and keep-scheme
 PASS Mixed-Content: Expects blocked for xhr to cross-http origin and no-redirect redirection from https context.
 PASS Mixed-Content: Expects blocked for xhr to cross-http origin and swap-scheme redirection from https context.
 PASS Mixed-Content: Expects blocked for xhr to cross-https origin and swap-scheme redirection from https context.
-FAIL Mixed-Content: Expects blocked for xhr to same-http origin and keep-scheme redirection from https context. assert_equals: The resource request should be 'blocked'. expected "blocked" but got "allowed"
-FAIL Mixed-Content: Expects blocked for xhr to same-http origin and no-redirect redirection from https context. assert_equals: The resource request should be 'blocked'. expected "blocked" but got "allowed"
-FAIL Mixed-Content: Expects blocked for xhr to same-http origin and swap-scheme redirection from https context. assert_equals: The resource request should be 'blocked'. expected "blocked" but got "allowed"
-FAIL Mixed-Content: Expects blocked for xhr to same-https origin and swap-scheme redirection from https context. assert_equals: The resource request should be 'blocked'. expected "blocked" but got "allowed"
+PASS Mixed-Content: Expects blocked for xhr to same-http origin and keep-scheme redirection from https context.
+PASS Mixed-Content: Expects blocked for xhr to same-http origin and no-redirect redirection from https context.
+PASS Mixed-Content: Expects blocked for xhr to same-http origin and swap-scheme redirection from https context.
+PASS Mixed-Content: Expects blocked for xhr to same-https origin and swap-scheme redirection from https context.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-module-data.meta/opt-in/fetch.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-module-data.meta/opt-in/fetch.https-expected.txt
@@ -1,5 +1,5 @@
 
 PASS Mixed-Content: Expects allowed for fetch to same-https origin and no-redirect redirection from https context.
 PASS Mixed-Content: Expects blocked for fetch to cross-http origin and no-redirect redirection from https context.
-FAIL Mixed-Content: Expects blocked for fetch to same-http origin and no-redirect redirection from https context. assert_equals: The resource request should be 'blocked'. expected "blocked" but got "allowed"
+PASS Mixed-Content: Expects blocked for fetch to same-http origin and no-redirect redirection from https context.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-module-data.meta/opt-in/websocket.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-module-data.meta/opt-in/websocket.https-expected.txt
@@ -1,5 +1,5 @@
 
 PASS Mixed-Content: Expects allowed for websocket to same-wss origin and no-redirect redirection from https context.
 PASS Mixed-Content: Expects blocked for websocket to cross-ws origin and no-redirect redirection from https context.
-FAIL Mixed-Content: Expects blocked for websocket to same-ws origin and no-redirect redirection from https context. assert_equals: The resource request should be 'blocked'. expected "blocked" but got "allowed"
+PASS Mixed-Content: Expects blocked for websocket to same-ws origin and no-redirect redirection from https context.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-module-data.meta/opt-in/xhr.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-module-data.meta/opt-in/xhr.https-expected.txt
@@ -1,5 +1,5 @@
 
 PASS Mixed-Content: Expects allowed for xhr to same-https origin and no-redirect redirection from https context.
 PASS Mixed-Content: Expects blocked for xhr to cross-http origin and no-redirect redirection from https context.
-FAIL Mixed-Content: Expects blocked for xhr to same-http origin and no-redirect redirection from https context. assert_equals: The resource request should be 'blocked'. expected "blocked" but got "allowed"
+PASS Mixed-Content: Expects blocked for xhr to same-http origin and no-redirect redirection from https context.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-module-data.meta/unset/fetch.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-module-data.meta/unset/fetch.https-expected.txt
@@ -4,7 +4,7 @@ PASS Mixed-Content: Expects allowed for fetch to same-https origin and no-redire
 PASS Mixed-Content: Expects blocked for fetch to cross-http origin and keep-scheme redirection from https context.
 PASS Mixed-Content: Expects blocked for fetch to cross-http origin and no-redirect redirection from https context.
 PASS Mixed-Content: Expects blocked for fetch to cross-http origin and swap-scheme redirection from https context.
-FAIL Mixed-Content: Expects blocked for fetch to same-http origin and keep-scheme redirection from https context. assert_equals: The resource request should be 'blocked'. expected "blocked" but got "allowed"
-FAIL Mixed-Content: Expects blocked for fetch to same-http origin and no-redirect redirection from https context. assert_equals: The resource request should be 'blocked'. expected "blocked" but got "allowed"
-FAIL Mixed-Content: Expects blocked for fetch to same-http origin and swap-scheme redirection from https context. assert_equals: The resource request should be 'blocked'. expected "blocked" but got "allowed"
+PASS Mixed-Content: Expects blocked for fetch to same-http origin and keep-scheme redirection from https context.
+PASS Mixed-Content: Expects blocked for fetch to same-http origin and no-redirect redirection from https context.
+PASS Mixed-Content: Expects blocked for fetch to same-http origin and swap-scheme redirection from https context.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-module-data.meta/unset/websocket.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-module-data.meta/unset/websocket.https-expected.txt
@@ -1,5 +1,5 @@
 
 PASS Mixed-Content: Expects allowed for websocket to same-wss origin and no-redirect redirection from https context.
 PASS Mixed-Content: Expects blocked for websocket to cross-ws origin and no-redirect redirection from https context.
-FAIL Mixed-Content: Expects blocked for websocket to same-ws origin and no-redirect redirection from https context. assert_equals: The resource request should be 'blocked'. expected "blocked" but got "allowed"
+PASS Mixed-Content: Expects blocked for websocket to same-ws origin and no-redirect redirection from https context.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-module-data.meta/unset/xhr.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-module-data.meta/unset/xhr.https-expected.txt
@@ -4,7 +4,7 @@ PASS Mixed-Content: Expects allowed for xhr to same-https origin and no-redirect
 PASS Mixed-Content: Expects blocked for xhr to cross-http origin and keep-scheme redirection from https context.
 PASS Mixed-Content: Expects blocked for xhr to cross-http origin and no-redirect redirection from https context.
 PASS Mixed-Content: Expects blocked for xhr to cross-http origin and swap-scheme redirection from https context.
-FAIL Mixed-Content: Expects blocked for xhr to same-http origin and keep-scheme redirection from https context. assert_equals: The resource request should be 'blocked'. expected "blocked" but got "allowed"
-FAIL Mixed-Content: Expects blocked for xhr to same-http origin and no-redirect redirection from https context. assert_equals: The resource request should be 'blocked'. expected "blocked" but got "allowed"
-FAIL Mixed-Content: Expects blocked for xhr to same-http origin and swap-scheme redirection from https context. assert_equals: The resource request should be 'blocked'. expected "blocked" but got "allowed"
+PASS Mixed-Content: Expects blocked for xhr to same-http origin and keep-scheme redirection from https context.
+PASS Mixed-Content: Expects blocked for xhr to same-http origin and no-redirect redirection from https context.
+PASS Mixed-Content: Expects blocked for xhr to same-http origin and swap-scheme redirection from https context.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/mixed-content/gen/top.http-rp/opt-in/sharedworker-import-data.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/mixed-content/gen/top.http-rp/opt-in/sharedworker-import-data.https-expected.txt
@@ -1,12 +1,12 @@
 
 PASS Mixed-Content: Expects allowed for sharedworker-import-data to same-https origin and keep-scheme redirection from https context.
 PASS Mixed-Content: Expects allowed for sharedworker-import-data to same-https origin and no-redirect redirection from https context.
-FAIL Mixed-Content: Expects blocked for sharedworker-import-data to cross-http origin and keep-scheme redirection from https context. assert_equals: The resource request should be 'blocked'. expected "blocked" but got "allowed"
-FAIL Mixed-Content: Expects blocked for sharedworker-import-data to cross-http origin and no-redirect redirection from https context. assert_equals: The resource request should be 'blocked'. expected "blocked" but got "allowed"
-FAIL Mixed-Content: Expects blocked for sharedworker-import-data to cross-http origin and swap-scheme redirection from https context. assert_equals: The resource request should be 'blocked'. expected "blocked" but got "allowed"
-FAIL Mixed-Content: Expects blocked for sharedworker-import-data to cross-https origin and swap-scheme redirection from https context. assert_equals: The resource request should be 'blocked'. expected "blocked" but got "allowed"
-FAIL Mixed-Content: Expects blocked for sharedworker-import-data to same-http origin and keep-scheme redirection from https context. assert_equals: The resource request should be 'blocked'. expected "blocked" but got "allowed"
-FAIL Mixed-Content: Expects blocked for sharedworker-import-data to same-http origin and no-redirect redirection from https context. assert_equals: The resource request should be 'blocked'. expected "blocked" but got "allowed"
-FAIL Mixed-Content: Expects blocked for sharedworker-import-data to same-http origin and swap-scheme redirection from https context. assert_equals: The resource request should be 'blocked'. expected "blocked" but got "allowed"
-FAIL Mixed-Content: Expects blocked for sharedworker-import-data to same-https origin and swap-scheme redirection from https context. assert_equals: The resource request should be 'blocked'. expected "blocked" but got "allowed"
+PASS Mixed-Content: Expects blocked for sharedworker-import-data to cross-http origin and keep-scheme redirection from https context.
+PASS Mixed-Content: Expects blocked for sharedworker-import-data to cross-http origin and no-redirect redirection from https context.
+PASS Mixed-Content: Expects blocked for sharedworker-import-data to cross-http origin and swap-scheme redirection from https context.
+PASS Mixed-Content: Expects blocked for sharedworker-import-data to cross-https origin and swap-scheme redirection from https context.
+PASS Mixed-Content: Expects blocked for sharedworker-import-data to same-http origin and keep-scheme redirection from https context.
+PASS Mixed-Content: Expects blocked for sharedworker-import-data to same-http origin and no-redirect redirection from https context.
+PASS Mixed-Content: Expects blocked for sharedworker-import-data to same-http origin and swap-scheme redirection from https context.
+PASS Mixed-Content: Expects blocked for sharedworker-import-data to same-https origin and swap-scheme redirection from https context.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/mixed-content/gen/top.meta/opt-in/sharedworker-import-data.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/mixed-content/gen/top.meta/opt-in/sharedworker-import-data.https-expected.txt
@@ -1,5 +1,5 @@
 
 PASS Mixed-Content: Expects allowed for sharedworker-import-data to same-https origin and no-redirect redirection from https context.
-FAIL Mixed-Content: Expects blocked for sharedworker-import-data to cross-http origin and no-redirect redirection from https context. assert_equals: The resource request should be 'blocked'. expected "blocked" but got "allowed"
-FAIL Mixed-Content: Expects blocked for sharedworker-import-data to same-http origin and no-redirect redirection from https context. assert_equals: The resource request should be 'blocked'. expected "blocked" but got "allowed"
+PASS Mixed-Content: Expects blocked for sharedworker-import-data to cross-http origin and no-redirect redirection from https context.
+PASS Mixed-Content: Expects blocked for sharedworker-import-data to same-http origin and no-redirect redirection from https context.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/mixed-content/gen/top.meta/unset/sharedworker-import-data.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/mixed-content/gen/top.meta/unset/sharedworker-import-data.https-expected.txt
@@ -1,10 +1,10 @@
 
 PASS Mixed-Content: Expects allowed for sharedworker-import-data to same-https origin and keep-scheme redirection from https context.
 PASS Mixed-Content: Expects allowed for sharedworker-import-data to same-https origin and no-redirect redirection from https context.
-FAIL Mixed-Content: Expects blocked for sharedworker-import-data to cross-http origin and keep-scheme redirection from https context. assert_equals: The resource request should be 'blocked'. expected "blocked" but got "allowed"
-FAIL Mixed-Content: Expects blocked for sharedworker-import-data to cross-http origin and no-redirect redirection from https context. assert_equals: The resource request should be 'blocked'. expected "blocked" but got "allowed"
-FAIL Mixed-Content: Expects blocked for sharedworker-import-data to cross-http origin and swap-scheme redirection from https context. assert_equals: The resource request should be 'blocked'. expected "blocked" but got "allowed"
-FAIL Mixed-Content: Expects blocked for sharedworker-import-data to same-http origin and keep-scheme redirection from https context. assert_equals: The resource request should be 'blocked'. expected "blocked" but got "allowed"
-FAIL Mixed-Content: Expects blocked for sharedworker-import-data to same-http origin and no-redirect redirection from https context. assert_equals: The resource request should be 'blocked'. expected "blocked" but got "allowed"
-FAIL Mixed-Content: Expects blocked for sharedworker-import-data to same-http origin and swap-scheme redirection from https context. assert_equals: The resource request should be 'blocked'. expected "blocked" but got "allowed"
+PASS Mixed-Content: Expects blocked for sharedworker-import-data to cross-http origin and keep-scheme redirection from https context.
+PASS Mixed-Content: Expects blocked for sharedworker-import-data to cross-http origin and no-redirect redirection from https context.
+PASS Mixed-Content: Expects blocked for sharedworker-import-data to cross-http origin and swap-scheme redirection from https context.
+PASS Mixed-Content: Expects blocked for sharedworker-import-data to same-http origin and keep-scheme redirection from https context.
+PASS Mixed-Content: Expects blocked for sharedworker-import-data to same-http origin and no-redirect redirection from https context.
+PASS Mixed-Content: Expects blocked for sharedworker-import-data to same-http origin and swap-scheme redirection from https context.
 

--- a/Source/WebCore/loader/MixedContentChecker.cpp
+++ b/Source/WebCore/loader/MixedContentChecker.cpp
@@ -30,6 +30,7 @@
 #include "config.h"
 #include "MixedContentChecker.h"
 
+#include "BlobURL.h"
 #include "Document.h"
 #include "LegacySchemeRegistry.h"
 #include "LocalFrame.h"
@@ -39,20 +40,66 @@
 
 namespace WebCore {
 
-static bool isDocumentSecure(const Document& document)
+static bool isNonLocalHostPotentiallyTrustworthyURL(const URL& url)
 {
-    // FIXME: Use document.isDocumentSecure(), instead of comparing against "https" scheme, when all ports stop using loopback in LayoutTests
-    // sandboxed iframes have an opaque origin so we should perform the mixed content check considering the origin
-    // the iframe would have had if it were not sandboxed.
-    return document.securityOrigin().protocol() == "https"_s || (document.securityOrigin().isOpaque() && document.url().protocolIs("https"_s));
+    if (!url.isValid()) return true;
+
+    // Secure Contexts
+    // W3C Candidate Recommendation Draft, 10 November 2023
+    // 3.2. Is url potentially trustworthy?
+
+    // We currently deviate from the mixed content spec, and do not consider localhost
+    // or loopback URLs as secure contexts if they do not use a secure scheme.
+    // https://bugs.webkit.org/show_bug.cgi?id=171934
+    if (SecurityOrigin::isLocalHostOrLoopbackIPAddress(url.host()))
+        return LegacySchemeRegistry::shouldTreatURLSchemeAsSecure(url.protocol());
+
+    // 2. If url’s scheme is "data", return "Potentially Trustworthy".
+    if (url.protocolIsData())
+        return true;
+
+    // 3. Return the result of executing § 3.1 Is origin potentially trustworthy? on url’s origin.
+    // NOTE: The origin of blob: URLs is the origin of the context in which they were created.
+    //       Therefore, blobs created in a trustworthy origin will themselves be potentially
+    //       trustworthy.
+    if (url.protocolIsBlob()) {
+        RefPtr origin = SecurityOrigin::createForBlobURL(url);
+
+        // We currently deviate from the mixed content spec, and do not consider localhost
+        // or loopback URLs as secure contexts if they do not use a secure scheme.
+        // https://bugs.webkit.org/show_bug.cgi?id=171934
+        if (SecurityOrigin::isLocalHostOrLoopbackIPAddress(origin->host()))
+            return LegacySchemeRegistry::shouldTreatURLSchemeAsSecure(origin->protocol());
+
+        return origin->isPotentiallyTrustworthy();
+    }
+    return shouldTreatAsPotentiallyTrustworthy(url);
 }
 
-static bool isDataContextSecure(const LocalFrame& frame)
+static bool hasNonLocalHostPotentiallyTrustworthyOrigin(const Document& document)
+{
+    auto& origin = document.securityOrigin();
+
+    // We currently deviate from the mixed content spec, and do not consider localhost
+    // or loopback URLs as secure contexts if they do not use a secure scheme.
+    // https://bugs.webkit.org/show_bug.cgi?id=171934
+    if (SecurityOrigin::isLocalHostOrLoopbackIPAddress(origin.host()))
+        return LegacySchemeRegistry::shouldTreatURLSchemeAsSecure(origin.protocol());
+
+    // sandboxed iframes have an opaque origin so we should perform the mixed content
+    // check considering the origin the iframe would have had if it were not sandboxed.
+    if (origin.isOpaque())
+        return !document.url().protocolIsData() && isNonLocalHostPotentiallyTrustworthyURL(document.url());
+
+    return origin.isPotentiallyTrustworthy();
+}
+
+static bool dataContextProhibitsMixedSecurityContexts(const LocalFrame& frame)
 {
     RefPtr document = frame.document();
 
     while (document) {
-        if (isDocumentSecure(*document))
+        if (hasNonLocalHostPotentiallyTrustworthyOrigin(*document))
             return true;
 
         RefPtr frame = document->frame();
@@ -74,12 +121,13 @@ static bool isDataContextSecure(const LocalFrame& frame)
     return false;
 }
 
-static bool isMixedContent(const Document& document, const URL& url)
+static bool prohibitsMixedSecurityContexts(const Document& document)
 {
-    if (isDocumentSecure(document) || (document.url().protocolIs("data"_s) && isDataContextSecure(*document.frame())))
-        return !SecurityOrigin::isSecure(url);
+    // https://www.w3.org/TR/mixed-content/#upgrade-algorithm
+    // Editor’s Draft, 23 February 2023
+    // 4.3. Does settings prohibit mixed security contexts?
 
-    return false;
+    return hasNonLocalHostPotentiallyTrustworthyOrigin(document) || (document.url().protocolIsData() && dataContextProhibitsMixedSecurityContexts(*document.frame()));
 }
 
 static void logConsoleWarning(const LocalFrame& frame, bool blocked, const URL& target, bool isUpgradingIPAddressAndLocalhostEnabled)
@@ -115,15 +163,17 @@ bool MixedContentChecker::shouldUpgradeInsecureContent(LocalFrame& frame, IsUpgr
 
     // https://www.w3.org/TR/mixed-content/#upgrade-algorithm
     // Editor’s Draft, 23 February 2023
-    // 4.1. Upgrade a mixed content request to a potentially trustworthy URL, if appropriate
-    if (!isMixedContent(*frame.document(), url))
+    // 4.1. Upgrade request to an a priori authenticated URL as mixed content, if appropriate
+
+    // 4.1.1.3 Does settings prohibit mixed security contexts? returns "Does Not Restrict Mixed Security Contents" when applied to request’s client.
+    if (!prohibitsMixedSecurityContexts(*document))
+        return false;
+
+    // 4.1.1.1, 4.1.1.2, 4.1.1.4, 4.1.1.5
+    if (!canModifyRequest(url, destination, initiator))
         return false;
 
     auto shouldUpgradeIPAddressAndLocalhostForTesting = document->settings().iPAddressAndLocalhostMixedContentUpgradeTestingEnabled();
-
-    // 4.1 The request's URL is not upgraded in the following cases.
-    if (!canModifyRequest(url, destination, initiator))
-        return false;
 
     logConsoleWarning(frame, /* blocked */ false, url, shouldUpgradeIPAddressAndLocalhostForTesting);
     return true;
@@ -131,31 +181,50 @@ bool MixedContentChecker::shouldUpgradeInsecureContent(LocalFrame& frame, IsUpgr
 
 bool MixedContentChecker::canModifyRequest(const URL& url, FetchOptions::Destination destination, Initiator initiator)
 {
-    // 4.1.1 request’s URL is a potentially trustworthy URL.
-    if (url.protocolIs("https"_s))
+    // 4.1.1.1 request’s URL is a potentially trustworthy URL.
+    if (isNonLocalHostPotentiallyTrustworthyURL(url))
         return false;
-    // 4.1.2 request’s URL’s host is an IP address.
-    if (URL::hostIsIPAddress(url.host()) && !shouldTreatAsPotentiallyTrustworthy(url))
+
+    // 4.1.1.2 request’s URL’s host is an IP address.
+    // We diverge from the spec when it comes to the loopback address, which consider as upgradable.
+    if (URL::hostIsIPAddress(url.host()) && !SecurityOrigin::isLocalHostOrLoopbackIPAddress(url.host()))
         return false;
-    // 4.1.4 request’s destination is not "image", "audio", or "video".
+
+    // 4.1.1.4 request’s destination is not "image", "audio", or "video".
     if (!destinationIsImageAudioOrVideo(destination))
         return false;
-    // 4.1.5 request’s destination is "image" and request’s initiator is "imageset".
-    auto schemeIsHandledBySchemeHandler = LegacySchemeRegistry::schemeIsHandledBySchemeHandler(url.protocol());
-    if (!schemeIsHandledBySchemeHandler && destinationIsImageAndInitiatorIsImageset(destination, initiator))
+
+    // 4.1.1.5 request’s destination is "image" and request’s initiator is "imageset".
+    if (destinationIsImageAndInitiatorIsImageset(destination, initiator))
         return false;
+
     return true;
 }
 
 bool MixedContentChecker::shouldBlockRequest(LocalFrame& frame, const URL& url, IsUpgradable isUpgradable)
 {
+    if (isUpgradable == IsUpgradable::Yes)
+        return false;
+
+    // https://www.w3.org/TR/mixed-content/#upgrade-algorithm
+    // Editor’s Draft, 23 February 2023
+    // 4.4. Should fetching request be blocked as mixed content?
+
     RefPtr document = frame.document();
     if (!document)
         return false;
-    if (!isMixedContent(*frame.document(), url))
+
+    // 4.4.1.1 Does settings prohibit mixed security contexts? returns "Does Not Restrict Mixed Security Contexts" when applied to request’s client.
+    if (!prohibitsMixedSecurityContexts(*frame.document()))
         return false;
-    if ((LegacySchemeRegistry::schemeIsHandledBySchemeHandler(url.protocol()) || shouldTreatAsPotentiallyTrustworthy(url)) && isUpgradable == IsUpgradable::Yes)
+
+    // 4.4.1.2  request’s URL is a potentially trustworthy URL.
+    if (isNonLocalHostPotentiallyTrustworthyURL(url))
         return false;
+
+    // 4.4.1.3 The user agent has been instructed to allow mixed content, as described in § 7.2 User Controls).
+    // 4.4.1.4 request’s destination is "document", and request’s target browsing context has no parent browsing context.
+
     logConsoleWarning(frame, /* blocked */ true, url, document->settings().iPAddressAndLocalhostMixedContentUpgradeTestingEnabled());
     return true;
 }
@@ -167,7 +236,7 @@ void MixedContentChecker::checkFormForMixedContent(LocalFrame& frame, const URL&
     if (url.protocolIsJavaScript())
         return;
 
-    if (!isMixedContent(*frame.document(), url))
+    if (!prohibitsMixedSecurityContexts(*frame.document()) || isNonLocalHostPotentiallyTrustworthyURL(url))
         return;
 
     auto message = makeString("The page at "_s, frame.document()->url().stringCenterEllipsizedToLength(), " contains a form which targets an insecure URL "_s, url.stringCenterEllipsizedToLength(), ".\n"_s);

--- a/Tools/TestWebKitAPI/Tests/WebCore/MixedContentChecker.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/MixedContentChecker.cpp
@@ -58,13 +58,16 @@ TEST(MixedContentChecker, CanModifyRequest)
         initiator
     ));
 
-    // Exception for 4.1.2 potentially truthworthy address
+    // Exception for 4.1.1 (request’s URL is a potentially trustworthy URL) and
+    // 4.1.2 (URL’s host is an IP address) when it comes to loopback
     ASSERT_TRUE(MixedContentChecker::canModifyRequest(
         URL { "http://127.0.0.1"_s },
         destination,
         initiator
     ));
 
+    // Exception for 4.1.1 (request’s URL is a potentially trustworthy URL) when it
+    // comes to localhost
     ASSERT_TRUE(MixedContentChecker::canModifyRequest(
         URL { "http://localhost"_s },
         destination,
@@ -97,12 +100,18 @@ TEST(MixedContentChecker, CanModifyRequest)
         Initiator::Imageset
     ));
 
-    // But if the scheme is handled by the handler, it is modifiable even if the initiator is "imageset".
+    // But if the scheme is handled by the handler, it is never modifiable
     LegacySchemeRegistry::registerURLSchemeAsHandledBySchemeHandler("custom"_s);
 
     ASSERT_TRUE(LegacySchemeRegistry::schemeIsHandledBySchemeHandler("custom"_s));
 
-    ASSERT_TRUE(MixedContentChecker::canModifyRequest(
+    ASSERT_FALSE(MixedContentChecker::canModifyRequest(
+        URL { "custom://example.com/cat.jpg"_s },
+        FetchOptions::Destination::Audio,
+        initiator
+    ));
+
+    ASSERT_FALSE(MixedContentChecker::canModifyRequest(
         URL { "custom://example.com/cat.jpg"_s },
         destination,
         Initiator::Imageset
@@ -111,10 +120,10 @@ TEST(MixedContentChecker, CanModifyRequest)
     // This exception won't apply if the cheme is not registered.
     ASSERT_FALSE(LegacySchemeRegistry::schemeIsHandledBySchemeHandler("custom2"_s));
 
-    ASSERT_FALSE(MixedContentChecker::canModifyRequest(
+    ASSERT_TRUE(MixedContentChecker::canModifyRequest(
         URL { "custom2://example.com/cat.jpg"_s },
-        destination,
-        Initiator::Imageset
+        FetchOptions::Destination::Audio,
+        initiator
     ));
 }
 


### PR DESCRIPTION
```
[mixed-content] Check if an URL is potentially trustworthy to block/upgrade
https://bugs.webkit.org/show_bug.cgi?id=297536

Reviewed by NOBODY (OOPS!).

The Mixed Content specification uses Secure Contexts' "potentially trustworthy"
definition for URLs and origins to decide whether a request can be loaded as-is
or needs to be blocked/upgraded.

This is a larger bucket than just checking whether we have an HTTPs URL or not,
and includes embedder-defined custom protocols (such as, custom protocols
defined by WKWebView users). It matches the URLs for which
`window.isSecureContext` would return true.

This patch does not fully align WebKit's implementation with the Mixed Content
specification. In particular, handling of localhost URLs is left unchanged:
they are always considered as potentially trustworthy, but we block HTTP loading
of them in secure contexts.

* LayoutTests/imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-classic-data.http-rp/opt-in/fetch.https-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-classic-data.http-rp/opt-in/websocket.https-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-classic-data.http-rp/opt-in/xhr.https-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-classic-data.meta/opt-in/fetch.https-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-classic-data.meta/opt-in/websocket.https-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-classic-data.meta/opt-in/xhr.https-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-classic-data.meta/unset/fetch.https-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-classic-data.meta/unset/websocket.https-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-classic-data.meta/unset/xhr.https-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-module-data.http-rp/opt-in/fetch.https-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-module-data.http-rp/opt-in/websocket.https-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-module-data.http-rp/opt-in/xhr.https-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-module-data.meta/opt-in/fetch.https-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-module-data.meta/opt-in/websocket.https-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-module-data.meta/opt-in/xhr.https-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-module-data.meta/unset/fetch.https-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-module-data.meta/unset/websocket.https-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/mixed-content/gen/sharedworker-module-data.meta/unset/xhr.https-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/mixed-content/gen/top.http-rp/opt-in/sharedworker-import-data.https-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/mixed-content/gen/top.meta/opt-in/sharedworker-import-data.https-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/mixed-content/gen/top.meta/unset/sharedworker-import-data.https-expected.txt:
* LayoutTests/platform/mac-sequoia-wk2/imported/w3c/web-platform-tests/content-security-policy/gen/top.meta/script-src-self/sharedworker-import.http-expected.txt:
* Source/WebCore/loader/MixedContentChecker.cpp:
(WebCore::isNonLocalHostPotentiallyTrustworthyURL):
(WebCore::hasNonLocalHostPotentiallyTrustworthyOrigin):
(WebCore::dataContextProhibitsMixedSecurityContexts):
(WebCore::prohibitsMixedSecurityContexts):
(WebCore::MixedContentChecker::shouldUpgradeInsecureContent):
(WebCore::MixedContentChecker::canModifyRequest):
(WebCore::MixedContentChecker::shouldBlockRequest):
(WebCore::MixedContentChecker::checkFormForMixedContent):
(WebCore::isDocumentSecure): Deleted.
(WebCore::isDataContextSecure): Deleted.
(WebCore::isMixedContent): Deleted.
* Tools/TestWebKitAPI/Tests/WebCore/MixedContentChecker.cpp:
(TestWebKitAPI::TEST(MixedContentChecker, CanModifyRequest)):
```

- https://github.com/WebKit/WebKit/pull/35552 marked custom schemes as "upgradable" for compatibility with WKWebView (https://bugs.webkit.org/show_bug.cgi?id=281883). However, I don't understand how it can possibly work: once we decide that a custom scheme is upgradable, how do we actually upgrade it? It's not like HTTP that has a clear mapping to HTTPS. As far as I can tell we only upgrade http and ws requests (https://github.com/WebKit/WebKit/blob/356f67eae83172534ddf23df2a69a017fbd05978/Source/WebCore/page/csp/ContentSecurityPolicy.cpp#L1151).

- We have a setting to control upgrading of localhost (`iPAddressAndLocalhostMixedContentUpgradeTestingEnabled`), but in MixedContentChecker.cpp is only used for building error messages. Would it make sense to move its handling to here, rather than in the `shouldUpgradeInsecureContent` callers? (separate PR?)

- Right now I made sure to keep the spec divergence we have when it comes to `http://127.0.0.1` and `http://localhost` (they should both be considered secure, but we consider them upgradable instead - https://bugs.webkit.org/show_bug.cgi?id=171934.). However, fixing it requires first changing how we run WPT (we use localhost in places where we shouldn't, I think?), which is way out of my knowledge.